### PR TITLE
Bug create database didn't work with Casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue with Invoke-Command returning errors during test and set.
-- Fixed issue with createing databases that casing would be lost.
+- Fixed issue with creating a database where casing could be lost on the 
+database name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue with Invoke-Command returning errors during test and set.
+- Fixed issue with createing databases that casing would be lost.

--- a/source/DSCResources/DSC_PostgreSqlDatabase/DSC_PostgreSqlDatabase.psm1
+++ b/source/DSCResources/DSC_PostgreSqlDatabase/DSC_PostgreSqlDatabase.psm1
@@ -125,16 +125,18 @@ function Set-TargetResource
     {
         if ($Ensure -eq 'Present')
         {
+            $createDatabaseString = '"CREATE DATABASE ""{0}""' -f $DatabaseName
             Write-Verbose -Message ($script:localizedData.CreatingDatabase -f $DatabaseName)
             Invoke-Command -ScriptBlock {
-                & $PsqlLocation -d 'postgres' -c "CREATE DATABASE $DatabaseName"
+                & $PsqlLocation -d 'postgres' -c $createDatabaseString
             }
         }
         else
         {
+            $deleteDatabaseString = '"DROP DATABASE ""{0}""' -f $DatabaseName
             Write-Verbose -Message ($script:localizedData.DeletingDatabase -f $DatabaseName)
             Invoke-Command -ScriptBlock {
-                & $PsqlLocation -d 'postgres' -c "DROP DATABASE $DatabaseName"
+                & $PsqlLocation -d 'postgres' -c $deleteDatabaseString
             }
         }
     }

--- a/source/DSCResources/DSC_PostgreSqlDatabase/DSC_PostgreSqlDatabase.psm1
+++ b/source/DSCResources/DSC_PostgreSqlDatabase/DSC_PostgreSqlDatabase.psm1
@@ -125,7 +125,7 @@ function Set-TargetResource
     {
         if ($Ensure -eq 'Present')
         {
-            $createDatabaseString = '"CREATE DATABASE ""{0}""' -f $DatabaseName
+            $createDatabaseString = '"CREATE DATABASE \"{0}\""' -f $DatabaseName
             Write-Verbose -Message ($script:localizedData.CreatingDatabase -f $DatabaseName)
             Invoke-Command -ScriptBlock {
                 & $PsqlLocation -d 'postgres' -c $createDatabaseString
@@ -133,7 +133,7 @@ function Set-TargetResource
         }
         else
         {
-            $deleteDatabaseString = '"DROP DATABASE ""{0}""' -f $DatabaseName
+            $deleteDatabaseString = '"DROP DATABASE \"{0}\""' -f $DatabaseName
             Write-Verbose -Message ($script:localizedData.DeletingDatabase -f $DatabaseName)
             Invoke-Command -ScriptBlock {
                 & $PsqlLocation -d 'postgres' -c $deleteDatabaseString

--- a/source/DSCResources/DSC_PostgreSqlScript/DSC_PostgreSqlScript.psm1
+++ b/source/DSCResources/DSC_PostgreSqlScript/DSC_PostgreSqlScript.psm1
@@ -65,7 +65,7 @@ function Get-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.ExecutingGetScript -f $GetFilePath,$DatabaseName)
         $getResult = Invoke-Command -ScriptBlock {
-            & $PsqlLocation -d $($DatabaseName.ToLower()) -f $GetFilePath
+            & $PsqlLocation -d $DatabaseName -f $GetFilePath
         }
     }
     catch [System.Management.Automation.CommandNotFoundException]
@@ -147,7 +147,7 @@ function Set-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.ExecutingSetScript -f $SetFilePath,$DatabaseName)
         Invoke-Command -ScriptBlock {
-            & $PsqlLocation -d $($DatabaseName.ToLower()) -f $SetFilePath 2>&1
+            & $PsqlLocation -d $DatabaseName -f $SetFilePath 2>&1
         }
     }
     catch [System.Management.Automation.CommandNotFoundException]
@@ -224,7 +224,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.ExecutingTestScript -f $TestFilePath,$DatabaseName)
         $null = Invoke-Command -ScriptBlock {
-            & $PsqlLocation -d $($DatabaseName.ToLower()) -f $TestFilePath 2>&1
+            & $PsqlLocation -d $DatabaseName -f $TestFilePath 2>&1
         }
 
         Write-Verbose -Message ($script:localizedData.ReturnValue -f $true)


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

Fixed an issue where capital characters were changed to lower when create databases.

### Added

- Added PostgreSqlInstall resource
  - Install Postgres with specified features
- Added PostgreSqlScript resource
  - Run T-SQL Scripts against Postgres
- Added PostgreSqlDatabase resource
  - Add and remove database in PostgresSql

### Changed

- Removed CreateDatabase from PostgreSqlScript

### Removed

### Fixed

- Fixed issue with Invoke-Command returning errors during test and set.
- Fixed issue with createing databases that casing would be lost.


## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [X] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [X] Resource documentation added/updated in README.md.
- [X] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/postgresqldsc/11)
<!-- Reviewable:end -->
